### PR TITLE
Setup clean architecture backend skeleton

### DIFF
--- a/CityPulse.sln
+++ b/CityPulse.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Api", "src/CityPulse.Api/CityPulse.Api.csproj", "{AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Application", "src/CityPulse.Application/CityPulse.Application.csproj", "{E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Domain", "src/CityPulse.Domain/CityPulse.Domain.csproj", "{7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Infrastructure", "src/CityPulse.Infrastructure/CityPulse.Infrastructure.csproj", "{9345C821-5F94-4F7E-A2D9-58A4A42D2D92}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Release|Any CPU.Build.0 = Release|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Release|Any CPU.Build.0 = Release|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # City-Pulse
+
+This repository contains a backend skeleton built using ASP.NET Core following the principles of Clean Architecture. The solution is organized into separate layers:
+
+- **CityPulse.Domain** – domain entities.
+- **CityPulse.Application** – application services and business logic.
+- **CityPulse.Infrastructure** – infrastructure and data access configured for PostgreSQL using Entity Framework Core.
+- **CityPulse.Api** – ASP.NET Core Web API project exposing the endpoints.
+
+## Configuration
+
+Update the connection string in `src/CityPulse.Api/appsettings.json` to point to your PostgreSQL database.
+
+## Building
+
+```bash
+dotnet build CityPulse.sln
+```
+
+## Running the API
+
+```bash
+dotnet run --project src/CityPulse.Api
+```

--- a/src/CityPulse.Api/CityPulse.Api.csproj
+++ b/src/CityPulse.Api/CityPulse.Api.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\CityPulse.Application\\CityPulse.Application.csproj" />
+    <ProjectReference Include="..\\CityPulse.Infrastructure\\CityPulse.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CityPulse.Api/Controllers/HealthController.cs
+++ b/src/CityPulse.Api/Controllers/HealthController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace CityPulse.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    public string Get() => "OK";
+}

--- a/src/CityPulse.Api/Program.cs
+++ b/src/CityPulse.Api/Program.cs
@@ -1,0 +1,14 @@
+using CityPulse.Application;
+using CityPulse.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/src/CityPulse.Api/appsettings.json
+++ b/src/CityPulse.Api/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=citypulse;Username=postgres;Password=postgres"
+  }
+}

--- a/src/CityPulse.Application/CityPulse.Application.csproj
+++ b/src/CityPulse.Application/CityPulse.Application.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\CityPulse.Domain\\CityPulse.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CityPulse.Application/DependencyInjection.cs
+++ b/src/CityPulse.Application/DependencyInjection.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CityPulse.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        // Register application services here
+        return services;
+    }
+}

--- a/src/CityPulse.Domain/CityPulse.Domain.csproj
+++ b/src/CityPulse.Domain/CityPulse.Domain.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CityPulse.Domain/Entities/Placeholder.cs
+++ b/src/CityPulse.Domain/Entities/Placeholder.cs
@@ -1,0 +1,7 @@
+namespace CityPulse.Domain.Entities;
+
+// Placeholder domain entity. Replace with your own entities.
+public class Placeholder
+{
+    public int Id { get; set; }
+}

--- a/src/CityPulse.Infrastructure/CityPulse.Infrastructure.csproj
+++ b/src/CityPulse.Infrastructure/CityPulse.Infrastructure.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\CityPulse.Application\\CityPulse.Application.csproj" />
+    <ProjectReference Include="..\\CityPulse.Domain\\CityPulse.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CityPulse.Infrastructure/DependencyInjection.cs
+++ b/src/CityPulse.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,16 @@
+using CityPulse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CityPulse.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
+        return services;
+    }
+}

--- a/src/CityPulse.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/CityPulse.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace CityPulse.Infrastructure.Persistence;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+
+    // TODO: Add DbSet properties for your entities
+}


### PR DESCRIPTION
## Summary
- streamline backend template with generic layers and health endpoint
- add PostgreSQL-ready infrastructure with EF Core and connection string template
- document project structure and configuration

## Testing
- `dotnet build CityPulse.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3a8b26a083218069e383320d68f1