### PR TITLE
Expand backend scaffolding with tests and docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # City-Pulse
+
+This repository is organized into separate frontend and backend projects.
+
+- **backend/** – ASP.NET Core backend following a Clean Architecture.
+- **frontend/** – placeholder for the React frontend.
+
+### Backend structure
+The backend solution under `backend/` contains the following projects:
+
+- **CityPulse.Domain** – domain entities.
+- **CityPulse.Application** – application services and business logic.
+- **CityPulse.Infrastructure** – infrastructure and data access configured for PostgreSQL using Entity Framework Core.
+- **CityPulse.Api** – ASP.NET Core Web API project exposing the endpoints.
+- **CityPulse.Tests** – xUnit test project with sample tests.
+
+### Configuration
+Update the connection string in `backend/CityPulse.Api/appsettings.json` (and the development variant) to point to your PostgreSQL database.
+
+### Building
+```
+dotnet build backend/CityPulse.sln
+```
+
+### Running the API
+```
+dotnet run --project backend/CityPulse.Api
+```
+
+The API includes a sample `Cities` endpoint at `/api/Cities` and a health check at `/api/Health`.
+
+### Running tests
+```
+dotnet test backend/CityPulse.sln
+```
+
+### Docker
+A `docker-compose.yml` is available under `backend/` to launch the API along with a PostgreSQL instance:
+```
+docker compose up --build
+```

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,7 @@
+**/bin/
+**/obj/
+.vs
+Dockerfile
+*.user
+*.suo
+*.vscode

--- a/backend/CityPulse.Api/CityPulse.Api.csproj
+++ b/backend/CityPulse.Api/CityPulse.Api.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\CityPulse.Application\\CityPulse.Application.csproj" />
+    <ProjectReference Include="..\\CityPulse.Infrastructure\\CityPulse.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/CityPulse.Api/Controllers/CitiesController.cs
+++ b/backend/CityPulse.Api/Controllers/CitiesController.cs
@@ -1,0 +1,49 @@
+using CityPulse.Application.Interfaces;
+using CityPulse.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CityPulse.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CitiesController : ControllerBase
+{
+    private readonly ICityService _service;
+
+    public CitiesController(ICityService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<IReadOnlyList<City>> GetAll() => await _service.ListAsync();
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<City>> Get(int id)
+    {
+        var city = await _service.GetAsync(id);
+        return city is null ? NotFound() : Ok(city);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<int>> Create(City city)
+    {
+        var id = await _service.CreateAsync(city);
+        return CreatedAtAction(nameof(Get), new { id }, id);
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> Update(int id, City city)
+    {
+        if (id != city.Id) return BadRequest();
+        await _service.UpdateAsync(city);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        await _service.DeleteAsync(id);
+        return NoContent();
+    }
+}

--- a/backend/CityPulse.Api/Controllers/HealthController.cs
+++ b/backend/CityPulse.Api/Controllers/HealthController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace CityPulse.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    public string Get() => "OK";
+}

--- a/backend/CityPulse.Api/Program.cs
+++ b/backend/CityPulse.Api/Program.cs
@@ -1,0 +1,22 @@
+using CityPulse.Application;
+using CityPulse.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
+
+app.Run();

--- a/backend/CityPulse.Api/Properties/launchSettings.json
+++ b/backend/CityPulse.Api/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "CityPulse.Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/backend/CityPulse.Api/appsettings.Development.json
+++ b/backend/CityPulse.Api/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=citypulse;Username=postgres;Password=postgres"
+  }
+}

--- a/backend/CityPulse.Api/appsettings.json
+++ b/backend/CityPulse.Api/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=citypulse;Username=postgres;Password=postgres"
+  }
+}

--- a/backend/CityPulse.Application/CityPulse.Application.csproj
+++ b/backend/CityPulse.Application/CityPulse.Application.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\CityPulse.Domain\\CityPulse.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/CityPulse.Application/DependencyInjection.cs
+++ b/backend/CityPulse.Application/DependencyInjection.cs
@@ -1,0 +1,14 @@
+using CityPulse.Application.Interfaces;
+using CityPulse.Application.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CityPulse.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddScoped<ICityService, CityService>();
+        return services;
+    }
+}

--- a/backend/CityPulse.Application/Interfaces/ICityRepository.cs
+++ b/backend/CityPulse.Application/Interfaces/ICityRepository.cs
@@ -1,0 +1,12 @@
+using CityPulse.Domain.Entities;
+
+namespace CityPulse.Application.Interfaces;
+
+public interface ICityRepository
+{
+    Task<City?> GetAsync(int id);
+    Task<IReadOnlyList<City>> ListAsync();
+    Task<int> AddAsync(City city);
+    Task UpdateAsync(City city);
+    Task DeleteAsync(int id);
+}

--- a/backend/CityPulse.Application/Interfaces/ICityService.cs
+++ b/backend/CityPulse.Application/Interfaces/ICityService.cs
@@ -1,0 +1,12 @@
+using CityPulse.Domain.Entities;
+
+namespace CityPulse.Application.Interfaces;
+
+public interface ICityService
+{
+    Task<City?> GetAsync(int id);
+    Task<IReadOnlyList<City>> ListAsync();
+    Task<int> CreateAsync(City city);
+    Task UpdateAsync(City city);
+    Task DeleteAsync(int id);
+}

--- a/backend/CityPulse.Application/Services/CityService.cs
+++ b/backend/CityPulse.Application/Services/CityService.cs
@@ -1,0 +1,24 @@
+using CityPulse.Application.Interfaces;
+using CityPulse.Domain.Entities;
+
+namespace CityPulse.Application.Services;
+
+public class CityService : ICityService
+{
+    private readonly ICityRepository _repository;
+
+    public CityService(ICityRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<City?> GetAsync(int id) => _repository.GetAsync(id);
+
+    public Task<IReadOnlyList<City>> ListAsync() => _repository.ListAsync();
+
+    public Task<int> CreateAsync(City city) => _repository.AddAsync(city);
+
+    public Task UpdateAsync(City city) => _repository.UpdateAsync(city);
+
+    public Task DeleteAsync(int id) => _repository.DeleteAsync(id);
+}

--- a/backend/CityPulse.Domain/CityPulse.Domain.csproj
+++ b/backend/CityPulse.Domain/CityPulse.Domain.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/backend/CityPulse.Domain/Common/BaseEntity.cs
+++ b/backend/CityPulse.Domain/Common/BaseEntity.cs
@@ -1,0 +1,8 @@
+namespace CityPulse.Domain.Common;
+
+public abstract class BaseEntity
+{
+    // Integer identifier to align with repository interfaces
+    public int Id { get; set; }
+}
+

--- a/backend/CityPulse.Domain/Entities/City.cs
+++ b/backend/CityPulse.Domain/Entities/City.cs
@@ -1,0 +1,10 @@
+using CityPulse.Domain.Common;
+
+namespace CityPulse.Domain.Entities;
+
+public class City : BaseEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Country { get; set; } = string.Empty;
+    public int Population { get; set; }
+}

--- a/backend/CityPulse.Infrastructure/CityPulse.Infrastructure.csproj
+++ b/backend/CityPulse.Infrastructure/CityPulse.Infrastructure.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\CityPulse.Domain\\CityPulse.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/CityPulse.Infrastructure/DependencyInjection.cs
+++ b/backend/CityPulse.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,21 @@
+using CityPulse.Application.Interfaces;
+using CityPulse.Infrastructure.Persistence;
+using CityPulse.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CityPulse.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseNpgsql(configuration.GetConnectionString("DefaultConnection")));
+
+        services.AddScoped<ICityRepository, CityRepository>();
+
+        return services;
+    }
+}

--- a/backend/CityPulse.Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/CityPulse.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,20 @@
+using CityPulse.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CityPulse.Infrastructure.Persistence;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<City> Cities => Set<City>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/backend/CityPulse.Infrastructure/Persistence/Configurations/CityConfiguration.cs
+++ b/backend/CityPulse.Infrastructure/Persistence/Configurations/CityConfiguration.cs
@@ -1,0 +1,15 @@
+using CityPulse.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CityPulse.Infrastructure.Persistence.Configurations;
+
+public class CityConfiguration : IEntityTypeConfiguration<City>
+{
+    public void Configure(EntityTypeBuilder<City> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Country).IsRequired().HasMaxLength(200);
+    }
+}

--- a/backend/CityPulse.Infrastructure/Repositories/CityRepository.cs
+++ b/backend/CityPulse.Infrastructure/Repositories/CityRepository.cs
@@ -1,0 +1,43 @@
+using CityPulse.Application.Interfaces;
+using CityPulse.Domain.Entities;
+using CityPulse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace CityPulse.Infrastructure.Repositories;
+
+public class CityRepository : ICityRepository
+{
+    private readonly AppDbContext _db;
+
+    public CityRepository(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<City?> GetAsync(int id) =>
+        await _db.Cities.FindAsync(id);
+
+    public async Task<IReadOnlyList<City>> ListAsync() =>
+        await _db.Cities.AsNoTracking().ToListAsync();
+
+    public async Task<int> AddAsync(City city)
+    {
+        _db.Cities.Add(city);
+        await _db.SaveChangesAsync();
+        return city.Id;
+    }
+
+    public async Task UpdateAsync(City city)
+    {
+        _db.Cities.Update(city);
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await _db.Cities.FindAsync(id);
+        if (entity is null) return;
+        _db.Cities.Remove(entity);
+        await _db.SaveChangesAsync();
+    }
+}

--- a/backend/CityPulse.Tests/CityPulse.Tests.csproj
+++ b/backend/CityPulse.Tests/CityPulse.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\CityPulse.Application\\CityPulse.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/CityPulse.Tests/CityServiceTests.cs
+++ b/backend/CityPulse.Tests/CityServiceTests.cs
@@ -1,0 +1,22 @@
+using CityPulse.Application.Interfaces;
+using CityPulse.Application.Services;
+using CityPulse.Domain.Entities;
+using Moq;
+using Xunit;
+
+namespace CityPulse.Tests;
+
+public class CityServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_ReturnsNewId()
+    {
+        var repo = new Mock<ICityRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<City>())).ReturnsAsync(1);
+        var service = new CityService(repo.Object);
+
+        var id = await service.CreateAsync(new City { Name = "Test" });
+
+        Assert.Equal(1, id);
+    }
+}

--- a/backend/CityPulse.http
+++ b/backend/CityPulse.http
@@ -1,0 +1,6 @@
+@hostname = localhost
+@port = 5000
+@host = {{hostname}}:{{port}}
+
+GET http://{{host}}/api/cities
+Accept: application/json

--- a/backend/CityPulse.sln
+++ b/backend/CityPulse.sln
@@ -1,0 +1,45 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Api", "CityPulse.Api/CityPulse.Api.csproj", "{AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Application", "CityPulse.Application/CityPulse.Application.csproj", "{E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Domain", "CityPulse.Domain/CityPulse.Domain.csproj", "{7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Infrastructure", "CityPulse.Infrastructure/CityPulse.Infrastructure.csproj", "{9345C821-5F94-4F7E-A2D9-58A4A42D2D92}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CityPulse.Tests", "CityPulse.Tests/CityPulse.Tests.csproj", "{36251F39-4931-4D58-9DA2-DE9336B9FBDC}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {AD96801B-DF63-4E2C-8D25-B4E0053A7C5B}.Release|Any CPU.Build.0 = Release|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {E4BA2FC4-B1A3-4A7D-B665-558B2A2F728C}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7F1C8B41-1F3C-4A53-B4AA-0D8B09C2C23A}.Release|Any CPU.Build.0 = Release|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {9345C821-5F94-4F7E-A2D9-58A4A42D2D92}.Release|Any CPU.Build.0 = Release|Any CPU
+        {36251F39-4931-4D58-9DA2-DE9336B9FBDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {36251F39-4931-4D58-9DA2-DE9336B9FBDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {36251F39-4931-4D58-9DA2-DE9336B9FBDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {36251F39-4931-4D58-9DA2-DE9336B9FBDC}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore CityPulse.sln
+RUN dotnet publish CityPulse.Api/CityPulse.Api.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "CityPulse.Api.dll"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    ports:
+      - "5000:80"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__Default=Host=db;Database=citypulse;Username=postgres;Password=postgres
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: citypulse
+    ports:
+      - "5432:5432"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,1 @@
+# CityPulse Frontend


### PR DESCRIPTION
## Summary
- add City entity and replace WeatherForecast sample
- wire up EF Core repository and service for City CRUD operations
- expose City API controller and adjust documentation
- standardize entity identifiers to integers

## Testing
- `apt-get update` *(fails: repository 403)*
- `dotnet build backend/CityPulse.sln` *(fails: command not found)*
- `dotnet test backend/CityPulse.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3a8b26a083218069e383320d68f1